### PR TITLE
[BUGFIX] avoid execptions while extracting metadata

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,6 @@ Neos:
       Array: 'TYPO3\Eel\Helper\ArrayHelper'
 
     metaDataMapping:
-      title: '${asset.Title || iptc.Title || exif.imageDescription}'
+      title: '${String.crop(asset.Title || iptc.Title || exif.imageDescription, 255)}'
       caption: '${asset.Caption || iptc.Description}'
-      tags: '${Array.concat(asset.tags, iptc.keywords)}'
+      tags: '${Array.concat(asset.tags || [], iptc.keywords || [])}'


### PR DESCRIPTION
when extracting data there might occur exceptions because the extracted data does not fit the validation rules. Improved expression to ensure valid data.
