### PR TITLE
Add compatability with Flow 7.0 / Neos 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "require": {
         "doctrine/collections": "^1.0",
-        "neos/media": "^3.0 || ^4.0 || ^5.0 || dev-master",
-        "neos/flow": "^4.0 || ^5.0 || ^6.0 || dev-master"
+        "neos/media": "^3.0 || ^4.0 || ^5.0 || ^7.0 || dev-master",
+        "neos/flow": "^4.0 || ^5.0 || ^6.0 || ^7.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Just added the 7.x branches to composer.json

To avoid future PR's like this, what do you think about using the following in composer.json?
```
        "neos/media": ">=3.0 || dev-master",
        "neos/flow": ">=4.0 || dev-master"
```

Shall I change the commit to allow all future media/flow versions?